### PR TITLE
add inj-tyfam-plugin example

### DIFF
--- a/example-plugins/cabal.project
+++ b/example-plugins/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  inj-tyfam-plugin

--- a/example-plugins/inj-tyfam-plugin/LICENSE
+++ b/example-plugins/inj-tyfam-plugin/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2020, Nicolas Frisby.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE CONTRIBUTORS ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/example-plugins/inj-tyfam-plugin/README.md
+++ b/example-plugins/inj-tyfam-plugin/README.md
@@ -1,0 +1,5 @@
+This barebones plugin addresses GHC Issue
+[#10833](https://gitlab.haskell.org/ghc/ghc/issues/10833).
+
+It demonstrates simplification of Given equality constraints and some
+very simple interpretation of FunEq constraints.

--- a/example-plugins/inj-tyfam-plugin/app/Main.hs
+++ b/example-plugins/inj-tyfam-plugin/app/Main.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE TypeFamilies #-}
+
+{-# OPTIONS_GHC -fplugin=Plugin.InjTyFam #-}
+{-# OPTIONS_GHC -dcore-lint #-}
+
+module Main (main) where
+
+import Prelim
+
+main :: IO ()
+main = test `seq` pure ()
+
+test :: (Id a ~ Id b) => a -> b
+test x = x

--- a/example-plugins/inj-tyfam-plugin/app/Prelim.hs
+++ b/example-plugins/inj-tyfam-plugin/app/Prelim.hs
@@ -1,0 +1,6 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+module Prelim (module Prelim) where
+
+type family Id a = r | r -> a

--- a/example-plugins/inj-tyfam-plugin/inj-tyfam-plugin.cabal
+++ b/example-plugins/inj-tyfam-plugin/inj-tyfam-plugin.cabal
@@ -1,0 +1,47 @@
+cabal-version: 2.4
+
+name: inj-tyfam-plugin
+version: 0.1.0.0
+-- synopsis:
+-- description:
+-- bug-reports:
+-- license:
+license-file: LICENSE
+author: Nicolas Frisby
+maintainer: nicolas.frisby@gmail.com
+-- copyright:
+-- category:
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:
+    src
+
+  exposed-modules:
+    Plugin.InjTyFam
+
+  build-depends:
+      base
+    , ghc
+
+  ghc-options:         -Wall
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wmissing-export-lists
+
+executable smoke
+  default-language: Haskell2010
+  main-is: Main.hs
+  hs-source-dirs:
+    app
+
+  build-depends:
+      base
+    , inj-tyfam-plugin
+
+  other-modules:
+    Prelim

--- a/example-plugins/inj-tyfam-plugin/src/Plugin/InjTyFam.hs
+++ b/example-plugins/inj-tyfam-plugin/src/Plugin/InjTyFam.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Plugin.InjTyFam (
+  plugin,
+  tcPlugin,
+  ) where
+
+import           Data.Maybe (fromMaybe)
+
+import qualified Coercion
+import qualified CoreSyn
+import qualified Plugins
+import           TcEvidence (EvTerm)
+import qualified TcPluginM
+import qualified TcRnMonad
+import qualified TcRnTypes
+import           TcRnTypes (Ct, Xi)
+import           TcType (TcType)
+import qualified TyCoRep
+import           TyCoRep (Coercion)
+import qualified TyCon
+import           TyCon (TyCon)
+import qualified Type
+import           VarEnv (VarEnv)
+import qualified VarEnv
+
+-- | Just 'tcPlugin', with 'Plugins.purePlugin' set
+
+plugin :: Plugins.Plugin
+plugin = Plugins.defaultPlugin
+    {
+      Plugins.pluginRecompile = Plugins.purePlugin
+    ,
+      Plugins.tcPlugin = \_opts -> pure tcPlugin
+    }
+
+-- | A typechecker plugin that decomposes Given equalities headed by
+-- an injective type family,
+-- <https://downloads.haskell.org/ghc/8.6.5/docs/html/users_guide/glasgow_exts.html#injective-type-families>
+--
+-- The plugin user is " opting in " to
+-- <https://gitlab.haskell.org/ghc/ghc/issues/10833>
+
+tcPlugin :: TcRnTypes.TcPlugin
+tcPlugin = TcRnTypes.TcPlugin
+    {
+      TcRnTypes.tcPluginInit = pure ()
+    ,
+      TcRnTypes.tcPluginSolve = \() gs ds ws -> do
+        let
+          fskEnv :: FskEnv
+          fskEnv = mkFskEnv gs
+
+        (uncurry TcRnTypes.TcPluginOk . mconcat) <$>
+          if null ds && null ws
+          then mapM (simplifyG fskEnv) gs   -- we handle G-mode
+          else pure []   -- GHC already handles W-mode
+    ,
+      TcRnTypes.tcPluginStop = \() -> pure ()
+    }
+
+-----
+
+type M = TcPluginM.TcPluginM
+
+-- | The arguments to 'TcRnTypes.TcPluginOk'
+
+type Ok = ([(EvTerm, Ct)], [Ct])
+
+-- | See 'tcPlugin'
+
+simplifyG :: FskEnv -> Ct -> M Ok
+simplifyG fskEnv ct =
+    case predTree of
+      Type.ClassPred{}  -> giveup   -- TODO don't need to unpack SCs, right?
+      Type.IrredPred{}  -> giveup
+      Type.ForAllPred{} -> giveup   -- TODO this is unreachable, right?
+      Type.EqPred eqRel lty rty -> case eqRel of
+          Type.ReprEq -> giveup   -- TODO anything useful to do here?
+          Type.NomEq  -> case (,) <$> prj lty <*> prj rty of
+              Nothing ->
+                  giveup   -- one side isn't an injective tyfam application
+              Just ((ltc, ltys), (rtc, rtys)) ->
+                  if ltc /= rtc then giveup else do
+                    -- both sides apply the same tyfam
+                    news <- go [] ltys rtys
+                    pure ([(ev, ct)], news)
+  where
+    ev :: EvTerm
+    ev = TcRnTypes.ctEvTerm $ TcRnTypes.cc_ev ct
+
+    prj :: TcType -> Maybe (TyCon, [Xi])
+    prj = splitInjTyFamApp_maybe . unfsk fskEnv
+
+    giveup :: M Ok
+    giveup = pure ([], [])
+
+    predTree :: Type.PredTree
+    predTree = Type.classifyPredType (TcRnTypes.ctPred ct)
+
+    go :: [Ct] -> [TcType] -> [TcType] -> M [Ct]
+    go acc []         []         = pure acc
+    go acc (lty:ltys) (rty:rtys) = do
+        new <- impliedGivenEq ct lty rty
+        go (new:acc) ltys rtys
+    go _   _          _          = error "impossible!"
+
+-- | Split an application of injective tycon into the tycon and its
+-- arguments that have fundeps
+
+splitInjTyFamApp_maybe :: TcType -> Maybe (TyCon, [TcType])
+splitInjTyFamApp_maybe t = do
+    (tc, args) <- Type.splitTyConApp_maybe t
+    case TyCon.tyConInjectivityInfo tc of
+        TyCon.NotInjective -> Nothing
+        TyCon.Injective is -> Just (tc, [ arg | (i, arg) <- zip is args, i ])
+
+-- | Emit a new Given equality constraint implied by another Given
+-- equality constraint
+
+impliedGivenEq :: Ct -> TcType -> TcType -> M Ct
+impliedGivenEq ct lty rty = do
+    let
+      new_co :: Coercion
+      new_co = Coercion.mkUnivCo
+        (TyCoRep.PluginProv "inj-tyfam-plugin")
+        TyCon.Nominal
+        lty
+        rty
+
+    -- TODO how to incorporate @ctEvId ct@? (see #15248 on GitLab ghc)
+    new_ev <- TcPluginM.newGiven
+      (TcRnTypes.bumpCtLocDepth (TcRnTypes.ctLoc ct))  -- TODO don't bump?
+      (Type.mkPrimEqPredRole TyCon.Nominal lty rty)
+      (CoreSyn.Coercion new_co)
+
+    pure $ TcRnTypes.mkNonCanonical new_ev
+
+-----
+
+-- | See 'mkFskEnv'
+
+type FskEnv = VarEnv (TyCon, [Xi])
+
+-- | An incremental map from the @FunEq@s
+--
+-- NOTE not necessarily idempotent
+
+mkFskEnv :: [Ct] -> FskEnv
+mkFskEnv cts =
+    VarEnv.mkVarEnv
+    [ (cc_fsk, (cc_fun, cc_tyargs))
+    | TcRnTypes.CFunEqCan{..} <- cts
+    ]
+
+unfsk :: FskEnv -> TcType -> TcType
+unfsk fskEnv t = fromMaybe t $ do
+    v <- Type.getTyVar_maybe t
+    uncurry Type.mkTyConApp <$> VarEnv.lookupVarEnv fskEnv v


### PR DESCRIPTION
This is an example plugin that address https://gitlab.haskell.org/ghc/ghc/issues/10833

It's quite simple. The `README.md` lists what it demonstrates.

It currently compiles with GHC 8.8, because that's what I had installed already.

When this merges, I'll create an issue to update the imports.