### PR TITLE
inj-tyfam-plugin: imports use new module hierarchy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist-newstyle/
+hie.yaml
+cabal.project.local

--- a/example-plugins/cabal.project
+++ b/example-plugins/cabal.project
@@ -1,2 +1,0 @@
-packages:
-  inj-tyfam-plugin

--- a/example-plugins/inj-tyfam-plugin/cabal.project
+++ b/example-plugins/inj-tyfam-plugin/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/example-plugins/inj-tyfam-plugin/inj-tyfam-plugin.cabal
+++ b/example-plugins/inj-tyfam-plugin/inj-tyfam-plugin.cabal
@@ -12,8 +12,14 @@ maintainer: nicolas.frisby@gmail.com
 -- copyright:
 -- category:
 
-library
+common common
   default-language: Haskell2010
+  build-depends:
+    base
+      >= 4.12.0 && < 4.16.0
+
+library
+  import: common
   hs-source-dirs:
     src
 
@@ -21,8 +27,8 @@ library
     Plugin.InjTyFam
 
   build-depends:
-      base
-    , ghc
+    ghc
+      >= 8.11.0 && < 8.13.0
 
   ghc-options:         -Wall
                        -Wcompat
@@ -34,14 +40,13 @@ library
                        -Wmissing-export-lists
 
 executable smoke
-  default-language: Haskell2010
+  import: common
   main-is: Main.hs
   hs-source-dirs:
     app
 
   build-depends:
-      base
-    , inj-tyfam-plugin
+    inj-tyfam-plugin
 
   other-modules:
     Prelim


### PR DESCRIPTION
Addresses #6 for the `inj-tyfam-plugin`, with very explicit module imports to make it obvious where imported entities come from.

Doesn't update `outline.md`.

Tested on a recent build of GHC 8.11.